### PR TITLE
Make local static STAC builds work without custom IO backends

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,13 @@
 
 ### Changed
 
+- **Local COG files work in custom builds**: `build_from_stac()` and
+  `build_from_table(..., enrich_cog=True)` can now index local tiled
+  GeoTIFF/COG files referenced by normal paths or `file://` URLs.
+- **Clearer STAC band-map checks**: `build_from_stac()` now catches missing or
+  mismatched STAC asset names before reading raster headers. For common
+  Sentinel-2-style catalogs with `B01`/`B02` asset names, Rasteret can infer the
+  map when no provider-specific map is registered.
 - **GeoDataFrame pixel outputs preserve AOI metadata**: `get_gdf(...)` joins
   non-geometry AOI table columns back to results by `geometry_id`.
 - **Runtime geometry docs now focus on user tools**: the former enriched

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -212,9 +212,9 @@ Before adding a dataset, work through this checklist:
 
 1. **Data source is reachable**: STAC API, static catalog, or GeoParquet
    file. Verify you can query it or read it with PyArrow.
-2. **Band map has at least one working COG**: Rasteret parses COG headers
-   during `build()`. If no asset can be parsed, Rasteret can't index or read
-   the dataset.
+2. **Band map points to real assets**: the values in `band_map` must match
+   asset names in the STAC items. For example, some Sentinel-2 catalogs use
+   asset names like `B02`, while others use names like `blue`.
 3. **End-to-end `build()` succeeds**: run `rasteret.build()` with a small
    scope and verify `len(col) > 0`.
 4. **License is verified from the authoritative source**: pull `license`,
@@ -227,7 +227,8 @@ Before adding a dataset, work through this checklist:
 
 For static STAC catalogs (no `/search` endpoint), set `static_catalog=True`
 on the descriptor. Rasteret uses `pystac.Catalog.from_file()` to traverse
-these catalogs with client-side bbox/date filtering.
+these catalogs with client-side bbox/date filtering. Static catalogs can point
+to cloud COGs or local tiled GeoTIFF/COG files.
 
 ## Public API discipline
 

--- a/docs/how-to/build-from-tables.md
+++ b/docs/how-to/build-from-tables.md
@@ -154,7 +154,8 @@ Rasteret uses that to build an `assets` value like:
 
 If your table already has separate URLs for separate single-band COGs, build an
 `assets` column instead. For example, `B04` and `B08` should point to different
-`href` values when they live in different files.
+`href` values when they live in different files. The `href` values can point to
+cloud files or local tiled GeoTIFF/COG files.
 
 ## When Enrichment Is Needed
 
@@ -223,6 +224,7 @@ If a requested band cannot be resolved, check:
 
 If COG header parsing fails for all assets, check whether the URLs require
 credentials, requester-pays configuration, URL rewriting, or a custom backend.
+For local files, a normal path like `/data/scene_B04.tif` is enough.
 
 For the exact runtime schema, see
 [Schema Contract](../explanation/schema-contract.md).

--- a/src/rasteret/__init__.py
+++ b/src/rasteret/__init__.py
@@ -186,6 +186,7 @@ def build_from_stac(
         max_concurrent=max_concurrent,
         backend=backend,
         static_catalog=static_catalog,
+        strict_band_map_validation=band_map is not None,
     )
 
     async def _build() -> Collection:
@@ -532,7 +533,6 @@ def build(
             stac_api=api,
             collection=descriptor.stac_collection or descriptor.id,
             data_source=descriptor.id,
-            band_map=descriptor.band_map,
             band_index_map=descriptor.band_index_map,
             bbox=bbox,
             date_range=date_range,

--- a/src/rasteret/cloud.py
+++ b/src/rasteret/cloud.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Buffer
 from dataclasses import dataclass, field
 from typing import ClassVar, Protocol, runtime_checkable
 
@@ -67,11 +68,11 @@ class StorageBackend(Protocol):
     fsspec, or a mocked reader for tests).
     """
 
-    async def get_range(self, url: str, start: int, length: int) -> bytes: ...
+    async def get_range(self, url: str, start: int, length: int) -> Buffer: ...
 
     async def get_ranges(
         self, url: str, ranges: list[tuple[int, int]]
-    ) -> list[bytes]: ...
+    ) -> list[Buffer]: ...
 
 
 class ObstoreBackend:
@@ -111,22 +112,20 @@ class ObstoreBackend:
             return url[len(self._url_prefix) :]
         return url
 
-    async def get_range(self, url: str, start: int, length: int) -> bytes:
+    async def get_range(self, url: str, start: int, length: int) -> Buffer:
         import obstore as obs
 
         path = self._resolve_path(url)
-        buf = await obs.get_range_async(self._store, path, start=start, length=length)
-        return bytes(buf)
+        return await obs.get_range_async(self._store, path, start=start, length=length)
 
-    async def get_ranges(self, url: str, ranges: list[tuple[int, int]]) -> list[bytes]:
+    async def get_ranges(self, url: str, ranges: list[tuple[int, int]]) -> list[Buffer]:
         import obstore as obs
 
         path = self._resolve_path(url)
         starts, lengths = zip(*ranges)
-        buffers = await obs.get_ranges_async(
+        return await obs.get_ranges_async(
             self._store, path, starts=list(starts), lengths=list(lengths)
         )
-        return [bytes(b) for b in buffers]
 
 
 def rewrite_url(url: str, config: CloudConfig | None) -> str:

--- a/src/rasteret/fetch/cog.py
+++ b/src/rasteret/fetch/cog.py
@@ -9,8 +9,10 @@ import contextlib
 import logging
 import math
 import re
+from collections.abc import Buffer
 from dataclasses import dataclass
 from datetime import timedelta as _timedelta
+from pathlib import Path
 from typing import Literal
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urlparse
@@ -259,6 +261,10 @@ class _AutoObstoreBackend:
                 break
         parsed = urlparse(url)
 
+        # --- Local filesystem paths -> LocalStore ---
+        if parsed.scheme in {"", "file"}:
+            return self._get_local_store(), self._local_store_path(url, parsed)
+
         # --- s3:// scheme -> S3Store ---
         if parsed.scheme == "s3":
             bucket = parsed.netloc
@@ -325,6 +331,34 @@ class _AutoObstoreBackend:
             )
             self._stores[origin] = store
         return store, parsed.path.lstrip("/")
+
+    def _get_local_store(self) -> object:
+        """Return a root-scoped LocalStore for local filesystem reads."""
+        cache_key = "file:///"
+        store = self._stores.get(cache_key)
+        if store is None:
+            from obstore.store import LocalStore
+
+            store = LocalStore.from_url(cache_key)
+            self._stores[cache_key] = store
+        return store
+
+    @staticmethod
+    def _local_store_path(url: str, parsed) -> str:
+        """Convert a local path or file URI to a LocalStore path."""
+        if parsed.scheme == "file":
+            if parsed.netloc not in {"", "localhost"}:
+                raise ValueError(
+                    f"Unsupported non-local file URI host: {parsed.netloc!r}"
+                )
+            path = Path(unquote(parsed.path))
+        else:
+            path = Path(url)
+
+        if not path.is_absolute():
+            path = Path.cwd() / path
+
+        return str(path).lstrip("/")
 
     def _get_s3_store(self, bucket: str) -> object:
         """Return a cached ``S3Store`` for *bucket*."""
@@ -465,14 +499,15 @@ class _AutoObstoreBackend:
     async def _retry_backoff(self, attempt: int) -> None:
         await asyncio.sleep(_SHORT_READ_BACKOFF_BASE_S * (2**attempt))
 
-    async def get_range(self, url: str, start: int, length: int) -> bytes:
+    async def get_range(self, url: str, start: int, length: int) -> Buffer:
         import obstore as obs
 
         for attempt in range(_SHORT_READ_RETRY_ATTEMPTS):
             store, path = self._store_for(url)
             try:
-                buf = await obs.get_range_async(store, path, start=start, length=length)
-                data = bytes(buf)
+                data = await obs.get_range_async(
+                    store, path, start=start, length=length
+                )
                 if len(data) != length:
                     raise self._truncated_read_error(url, start, length, len(data))
                 return data
@@ -537,7 +572,7 @@ class _AutoObstoreBackend:
 
         raise RuntimeError("Unexpected range-read retry flow fell through")
 
-    async def get_ranges(self, url: str, ranges: list[tuple[int, int]]) -> list[bytes]:
+    async def get_ranges(self, url: str, ranges: list[tuple[int, int]]) -> list[Buffer]:
         if not ranges:
             return []
 
@@ -547,10 +582,9 @@ class _AutoObstoreBackend:
         for attempt in range(_SHORT_READ_RETRY_ATTEMPTS):
             store, path = self._store_for(url)
             try:
-                buffers = await obs.get_ranges_async(
+                data = await obs.get_ranges_async(
                     store, path, starts=list(starts), lengths=list(lengths)
                 )
-                data = [bytes(b) for b in buffers]
                 if len(data) != len(lengths):
                     raise IOError(
                         "Truncated multi-range response for "
@@ -791,31 +825,11 @@ class COGReader:
 
         return out
 
-    async def _read_range(self, url: str, start: int, end: int) -> bytes:
+    async def _read_range(self, url: str, start: int, end: int) -> Buffer:
         """Read a byte range via the storage backend."""
         length = end - start
         if length < 0:
             raise ValueError(f"Invalid range: start={start}, end={end}")
-        # Local file paths are handled directly, regardless of backend.
-        parsed = urlparse(url)
-        if parsed.scheme in {"", "file"}:
-            path = unquote(parsed.path) if parsed.scheme == "file" else url
-
-            def _read_local() -> bytes:
-                with open(path, "rb") as f:
-                    f.seek(start)
-                    return f.read(length)
-
-            async with self.sem:
-                data = await asyncio.to_thread(_read_local)
-                if len(data) != length:
-                    raise IOError(
-                        "Truncated local range response for "
-                        f"{path}: requested bytes={start}..{end}, "
-                        f"expected {length} bytes, got {len(data)}."
-                    )
-                return data
-
         async with self.sem:
             data = await self._backend.get_range(url, start, length)
             if len(data) != length:

--- a/src/rasteret/fetch/header_parser.py
+++ b/src/rasteret/fetch/header_parser.py
@@ -80,6 +80,16 @@ def _parse_nodata(raw: str) -> float | int | None:
     return value
 
 
+def _decode_buffer(value: Any, encoding: str, errors: str = "replace") -> str:
+    """Decode bytes-like TIFF tag payloads without requiring Python ``bytes``."""
+    if isinstance(value, str):
+        return value
+    try:
+        return memoryview(value).tobytes().decode(encoding, errors=errors)
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return ""
+
+
 def get_crs_from_tiff_tags(tags: dict[int, Any]) -> int | None:
     """Extract CRS (EPSG code) from GeoTIFF tags.
 
@@ -383,11 +393,8 @@ class AsyncCOGHeaderParser:
                 nodata_str = (
                     raw_nodata[0] if isinstance(raw_nodata, tuple) else raw_nodata
                 )
-                if isinstance(nodata_str, (bytes, bytearray)):
-                    try:
-                        nodata_str = nodata_str.decode("ascii", errors="ignore")
-                    except (UnicodeDecodeError, AttributeError):
-                        nodata_str = ""
+                if not isinstance(nodata_str, str):
+                    nodata_str = _decode_buffer(nodata_str, "ascii", errors="ignore")
                 if isinstance(nodata_str, str) and nodata_str:
                     nodata = _parse_nodata(nodata_str)
             else:
@@ -395,11 +402,8 @@ class AsyncCOGHeaderParser:
                 # instead of the dedicated GDAL_NODATA tag.
                 raw_xml = tags.get(TAG_GDAL_METADATA)
                 xml_str = raw_xml[0] if isinstance(raw_xml, tuple) else raw_xml
-                if isinstance(xml_str, (bytes, bytearray)):
-                    try:
-                        xml_str = xml_str.decode("utf-8", errors="ignore")
-                    except (UnicodeDecodeError, AttributeError):
-                        xml_str = ""
+                if not isinstance(xml_str, str):
+                    xml_str = _decode_buffer(xml_str, "utf-8", errors="ignore")
                 if isinstance(xml_str, str) and xml_str.strip():
                     try:
                         import xml.etree.ElementTree as ET
@@ -622,7 +626,9 @@ class AsyncCOGHeaderParser:
             return struct.unpack(f"{endian}{count}B", data[:total_size])
         if type_id == 2:  # ASCII
             raw = data[:total_size]
-            return (raw[: max(0, count - 1)].decode("ascii", errors="replace"),)
+            return (
+                _decode_buffer(raw[: max(0, count - 1)], "ascii", errors="replace"),
+            )
         if type_id == 3:  # SHORT
             return struct.unpack(f"{endian}{count}H", data[:total_size])
         if type_id == 4:  # LONG

--- a/src/rasteret/ingest/normalize.py
+++ b/src/rasteret/ingest/normalize.py
@@ -10,6 +10,7 @@ construct a :class:`~rasteret.core.collection.Collection`.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Sequence
 from datetime import datetime
@@ -52,6 +53,24 @@ def parse_epsg(crs_value: object) -> int | None:
                 return int(s.split(":", 1)[1])
             except ValueError:
                 return None
+        if s.isdigit():
+            try:
+                return int(s)
+            except ValueError:
+                return None
+        try:
+            from pyproj import CRS
+
+            return CRS.from_user_input(crs_value).to_epsg()
+        except Exception:
+            return None
+    if isinstance(crs_value, dict):
+        try:
+            from pyproj import CRS
+
+            return CRS.from_json_dict(crs_value).to_epsg()
+        except Exception:
+            return None
     return None
 
 
@@ -67,10 +86,103 @@ def normalize_crs_code(crs_value: object) -> str | None:
     epsg = parse_epsg(crs_value)
     if epsg is not None:
         return crs_code_from_epsg(epsg)
+    if isinstance(crs_value, dict):
+        try:
+            from pyproj import CRS
+
+            crs = CRS.from_json_dict(crs_value)
+            authority = crs.to_authority()
+            if authority is not None:
+                return f"{authority[0]}:{authority[1]}"
+            return crs.to_string()
+        except Exception:
+            return json.dumps(crs_value, sort_keys=True)
     if isinstance(crs_value, str):
         value = crs_value.strip()
+        if not value:
+            return None
+        try:
+            from pyproj import CRS
+
+            crs = CRS.from_user_input(value)
+            authority = crs.to_authority()
+            if authority is not None:
+                return f"{authority[0]}:{authority[1]}"
+            return crs.to_string()
+        except Exception:
+            pass
         return value or None
     return None
+
+
+def normalize_raster_crs_sidecars(
+    table: pa.Table,
+    *,
+    required_columns: Sequence[str] | None = None,
+) -> pa.Table:
+    """Normalize row-level raster CRS sidecars from common source fields.
+
+    Priority per row:
+    1. ``proj:code``
+    2. ``proj:epsg``
+    3. ``crs``
+    4. ``proj:wkt2``
+    5. ``proj:projjson``
+    """
+    required = set(required_columns) if required_columns is not None else None
+    names = set(table.schema.names)
+    if required is not None and "proj:epsg" not in required and "crs" not in required:
+        return table
+
+    candidate_columns = [
+        name
+        for name in ("proj:code", "proj:epsg", "crs", "proj:wkt2", "proj:projjson")
+        if name in names
+    ]
+    if not candidate_columns:
+        return table
+
+    candidate_values = {
+        name: table.column(name).to_pylist() for name in candidate_columns
+    }
+    row_count = len(table)
+    epsg_values: list[int | None] = []
+    crs_values: list[str | None] = []
+
+    for idx in range(row_count):
+        epsg_value: int | None = None
+        crs_value: str | None = None
+        for name in ("proj:code", "proj:epsg", "crs", "proj:wkt2", "proj:projjson"):
+            values = candidate_values.get(name)
+            if values is None:
+                continue
+            raw = values[idx]
+            if epsg_value is None:
+                epsg_value = parse_epsg(raw)
+            if crs_value is None:
+                crs_value = normalize_crs_code(raw)
+            if epsg_value is not None and crs_value is not None:
+                break
+        epsg_values.append(epsg_value)
+        crs_values.append(crs_value or crs_code_from_epsg(epsg_value))
+
+    if required is None or "proj:epsg" in required:
+        epsg_col = pa.array(epsg_values, type=pa.int32())
+        if "proj:epsg" in names:
+            idx = table.schema.get_field_index("proj:epsg")
+            table = table.set_column(idx, "proj:epsg", epsg_col)
+        else:
+            table = table.append_column("proj:epsg", epsg_col)
+
+    if required is None or "crs" in required:
+        crs_col = pa.array(crs_values, type=pa.string())
+        if "crs" in names:
+            idx = table.schema.get_field_index("crs")
+            table = table.set_column(idx, "crs", crs_col)
+        else:
+            table = table.append_column("crs", crs_col)
+
+    return table
 
 
 def _add_bbox_struct(table: pa.Table) -> pa.Table:
@@ -183,6 +295,8 @@ def build_collection_from_table(
     table, transformed_geometry = _ensure_footprint_geometry_crs84(table)
     if transformed_geometry:
         table = _drop_column_if_present(table, "bbox")
+
+    table = normalize_raster_crs_sidecars(table)
 
     # Add canonical bbox if absent.
     if "bbox" not in table.schema.names:

--- a/src/rasteret/ingest/parquet_record_table.py
+++ b/src/rasteret/ingest/parquet_record_table.py
@@ -33,8 +33,7 @@ from rasteret.cloud import StorageBackend
 from rasteret.ingest.base import CollectionBuilder
 from rasteret.ingest.normalize import (
     build_collection_from_table,
-    normalize_crs_code,
-    parse_epsg,
+    normalize_raster_crs_sidecars,
 )
 from rasteret.integrations.huggingface import is_hf_dataset_uri, load_hf_parquet_table
 
@@ -133,25 +132,7 @@ def prepare_record_table(
             )
         table = table.append_column("assets", pa.array(assets_list))
 
-    # --- crs/proj:epsg: normalize CRS sidecars ---
-    if (
-        "proj:epsg" not in names
-        and "crs" in names
-        and (required is None or "proj:epsg" in required)
-    ):
-        crs_values = table.column("crs").to_pylist()
-        epsg_array = pa.array([parse_epsg(v) for v in crs_values], type=pa.int32())
-        table = table.append_column("proj:epsg", epsg_array)
-        names.add("proj:epsg")
-
-    if "crs" in names and (required is None or "crs" in required):
-        crs_values = table.column("crs").to_pylist()
-        crs_array = pa.array(
-            [normalize_crs_code(v) for v in crs_values], type=pa.string()
-        )
-        table = table.set_column(table.schema.get_field_index("crs"), "crs", crs_array)
-
-    return table
+    return normalize_raster_crs_sidecars(table, required_columns=required_columns)
 
 
 def _apply_column_map_aliases(

--- a/src/rasteret/ingest/stac_indexer.py
+++ b/src/rasteret/ingest/stac_indexer.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import pyarrow as pa
 import pystac_client
@@ -34,6 +35,7 @@ from rasteret.ingest.normalize import build_collection_from_table
 from rasteret.types import BoundingBox, DateRange
 
 logger = logging.getLogger(__name__)
+_STATIC_BAND_MAP_PREFLIGHT_ITEMS = 20
 
 
 def _is_retryable_stac_api_error(exc: Exception) -> bool:
@@ -136,6 +138,7 @@ class StacCollectionBuilder(CollectionBuilder):
                 "No STAC scenes matched the request "
                 f"(bbox={bbox}, date_range={date_range}, query={query})."
             )
+        self._ensure_band_map_matches_assets(stac_items)
 
         # 2. Process in batches, adding COG metadata
         processed_items = await self._enrich_with_cog_metadata(stac_items)
@@ -386,9 +389,6 @@ class StacCollectionBuilder(CollectionBuilder):
                 )
                 await asyncio.sleep(sleep_s)
 
-        # Planetary Computer SAS signing
-        from urllib.parse import urlparse
-
         host = urlparse(self.stac_api).netloc.lower()
         if "planetarycomputer.microsoft.com" in host:
             # If an obstore backend is provided, prefer native AzureStore reads
@@ -471,6 +471,7 @@ class StacCollectionBuilder(CollectionBuilder):
                 )
 
         items: list[dict] = []
+        band_map_preflight_done = False
         for item in catalog.get_all_items():
             # Resolve relative hrefs to absolute URLs
             item.make_asset_hrefs_absolute()
@@ -495,10 +496,112 @@ class StacCollectionBuilder(CollectionBuilder):
                         continue
 
             items.append(item_dict)
+            if (
+                not band_map_preflight_done
+                and len(items) >= _STATIC_BAND_MAP_PREFLIGHT_ITEMS
+            ):
+                self._ensure_band_map_matches_assets(items)
+                band_map_preflight_done = True
             if max_items and len(items) >= max_items:
                 break
 
+        if items and not band_map_preflight_done:
+            self._ensure_band_map_matches_assets(items)
+
         return items
+
+    def _ensure_band_map_matches_assets(self, stac_items: list[dict]) -> None:
+        """Resolve or validate band mapping before expensive COG header reads."""
+        asset_keys = self._collect_asset_keys(stac_items)
+        explicit_map = self._band_map is not None
+        resolved = self.band_map
+
+        if resolved and self._mapped_asset_keys(resolved, asset_keys):
+            return
+
+        if not explicit_map:
+            inferred = self._infer_band_map_from_assets(asset_keys)
+            if inferred:
+                self._band_map = inferred
+                logger.info(
+                    "Inferred STAC band map for %s from asset keys: %s",
+                    self.data_source,
+                    inferred,
+                )
+                return
+
+        detected = self._format_asset_keys(asset_keys)
+        if resolved:
+            expected = self._format_asset_keys(set(resolved.values()))
+            raise ValueError(
+                "No STAC asset keys matched the resolved band_map. "
+                f"Expected one of: {expected}. Detected asset keys: {detected}. "
+                "Pass band_map={band: asset_key} with asset keys present in the "
+                "STAC items, or use a registered data_source with matching asset "
+                "conventions."
+            )
+
+        raise ValueError(
+            "No band_map is configured for this STAC source, and Rasteret could "
+            f"not infer one from detected asset keys: {detected}. Pass "
+            "band_map={band: asset_key} explicitly or register a BandRegistry "
+            "mapping for this data_source."
+        )
+
+    @staticmethod
+    def _collect_asset_keys(stac_items: list[dict]) -> set[str]:
+        keys: set[str] = set()
+        for item in stac_items:
+            assets = item.get("assets") or {}
+            if isinstance(assets, dict):
+                keys.update(str(key) for key in assets.keys())
+        return keys
+
+    @staticmethod
+    def _mapped_asset_keys(band_map: dict[str, str], asset_keys: set[str]) -> set[str]:
+        return {asset for asset in band_map.values() if asset in asset_keys}
+
+    def _infer_band_map_from_assets(self, asset_keys: set[str]) -> dict[str, str]:
+        """Infer provider asset conventions from registered dataset band maps."""
+        if not asset_keys:
+            return {}
+
+        candidate_sources = [
+            self.data_source,
+            self.stac_collection,
+            *BandRegistry.list_registered(),
+        ]
+        seen: set[str] = set()
+        best: dict[str, str] = {}
+        for source in candidate_sources:
+            if not source or source in seen:
+                continue
+            seen.add(source)
+            registered = BandRegistry.get(source)
+            if not registered:
+                continue
+
+            provider_map = {
+                band: asset for band, asset in registered.items() if asset in asset_keys
+            }
+            if len(provider_map) > len(best):
+                best = provider_map
+
+            identity_map = {band: band for band in registered if band in asset_keys}
+            if len(identity_map) > len(best):
+                best = identity_map
+
+        return best
+
+    @staticmethod
+    def _format_asset_keys(asset_keys: set[str], limit: int = 20) -> str:
+        if not asset_keys:
+            return "<none>"
+        ordered = sorted(asset_keys)
+        shown = ", ".join(ordered[:limit])
+        if len(ordered) > limit:
+            shown = f"{shown}, ... (+{len(ordered) - limit} more)"
+        return shown
 
     def _rewrite_asset_url(self, asset: dict) -> None:
         """Rewrite a single asset URL in-place using cloud_config patterns."""

--- a/src/rasteret/ingest/stac_indexer.py
+++ b/src/rasteret/ingest/stac_indexer.py
@@ -31,7 +31,11 @@ from rasteret.core.geometry import geojson_dicts_to_wkb
 from rasteret.fetch.header_parser import AsyncCOGHeaderParser
 from rasteret.ingest.base import CollectionBuilder
 from rasteret.ingest.enrich import add_band_metadata_columns, slice_tile_tables_for_band
-from rasteret.ingest.normalize import build_collection_from_table
+from rasteret.ingest.normalize import (
+    build_collection_from_table,
+    crs_code_from_epsg,
+    parse_epsg,
+)
 from rasteret.types import BoundingBox, DateRange
 
 logger = logging.getLogger(__name__)
@@ -234,18 +238,24 @@ class StacCollectionBuilder(CollectionBuilder):
                 "band_index": band_index,
             }
 
+        record_crs_by_id = self._resolve_record_crs_by_id(stac_items, processed_items)
+
         rows = []
         geojson_geoms = []
         for item in stac_items:
             props = item.get("properties", {})
+            record_id = item["id"]
+            record_epsg = record_crs_by_id.get(record_id)
             row = {
-                "id": item["id"],
-                "assets": assets_by_id.get(item["id"], {}),
+                "id": record_id,
+                "assets": assets_by_id.get(record_id, {}),
             }
             geojson_geoms.append(item["geometry"])
             # Flatten STAC properties to top-level columns
             for key, value in props.items():
                 row[key] = value
+            row["proj:epsg"] = record_epsg
+            row["crs"] = crs_code_from_epsg(record_epsg)
             row["collection"] = item.get("collection") or self.stac_collection
             rows.append(row)
 
@@ -321,6 +331,67 @@ class StacCollectionBuilder(CollectionBuilder):
         )
 
         return table
+
+    def _resolve_record_crs_by_id(
+        self,
+        stac_items: list[dict],
+        processed_items: list[dict],
+    ) -> dict[str, int]:
+        """Resolve one raster CRS per STAC record.
+
+        Priority:
+        1. STAC ``proj:code`` when parseable
+        2. Legacy STAC ``proj:epsg`` when parseable
+        3. COG-header CRS parsed during enrichment
+        """
+        header_crs_by_id: dict[str, int] = {}
+        for item in processed_items:
+            record_id = item.get("record_id")
+            raw_crs = item.get("crs")
+            if not record_id or raw_crs is None:
+                continue
+            crs_val = int(raw_crs)
+            prev = header_crs_by_id.get(record_id)
+            if prev is None:
+                header_crs_by_id[record_id] = crs_val
+            elif prev != crs_val:
+                raise ValueError(
+                    "Conflicting CRS values detected during STAC enrichment for "
+                    f"record '{record_id}' ({prev} vs {crs_val}). "
+                    "Ensure all assets in a record share the same proj:epsg."
+                )
+
+        record_crs_by_id: dict[str, int] = {}
+        missing_ids: list[str] = []
+        for item in stac_items:
+            record_id = str(item["id"])
+            props = item.get("properties") or {}
+            resolved_epsg = (
+                parse_epsg(props.get("proj:code"))
+                or parse_epsg(props.get("proj:epsg"))
+                or parse_epsg(props.get("crs"))
+                or parse_epsg(props.get("proj:wkt2"))
+                or parse_epsg(props.get("proj:projjson"))
+                or header_crs_by_id.get(record_id)
+            )
+            if resolved_epsg is None:
+                missing_ids.append(record_id)
+                continue
+            record_crs_by_id[record_id] = resolved_epsg
+
+        if missing_ids:
+            sample = ", ".join(missing_ids[:5])
+            extra = f" (+{len(missing_ids) - 5} more)" if len(missing_ids) > 5 else ""
+            raise ValueError(
+                "Raster CRS could not be resolved for selected STAC items. "
+                "Rasteret requires one raster CRS per record for spatial reads. "
+                "Provide STAC projection metadata (`proj:code` preferred, legacy "
+                "`proj:epsg` also accepted), or use assets whose GeoTIFF headers "
+                "expose CRS metadata. Missing CRS record ids: "
+                f"{sample}{extra}."
+            )
+
+        return record_crs_by_id
 
     # ------------------------------------------------------------------
     # STAC search + URL signing
@@ -723,6 +794,7 @@ class StacCollectionBuilder(CollectionBuilder):
                     "extra_samples": list(metadata.extra_samples)
                     if metadata.extra_samples
                     else None,
+                    "crs": metadata.crs,
                     "href": href,
                     "band_index": band_index,
                 }

--- a/src/rasteret/ingest/stac_indexer.py
+++ b/src/rasteret/ingest/stac_indexer.py
@@ -82,6 +82,7 @@ class StacCollectionBuilder(CollectionBuilder):
         max_concurrent: int = 300,
         backend: StorageBackend | None = None,
         static_catalog: bool = False,
+        strict_band_map_validation: bool = False,
     ):
         super().__init__(
             name=name or "",
@@ -97,6 +98,7 @@ class StacCollectionBuilder(CollectionBuilder):
         self.batch_size = 100
         self._backend = backend
         self.static_catalog = static_catalog
+        self.strict_band_map_validation = strict_band_map_validation
 
     @property
     def band_map(self) -> dict[str, str]:
@@ -580,7 +582,7 @@ class StacCollectionBuilder(CollectionBuilder):
         resolved = self.band_map
 
         if resolved:
-            if explicit_map:
+            if explicit_map and self.strict_band_map_validation:
                 missing = set(resolved.values()) - asset_keys
                 if not missing:
                     return

--- a/src/rasteret/ingest/stac_indexer.py
+++ b/src/rasteret/ingest/stac_indexer.py
@@ -35,7 +35,6 @@ from rasteret.ingest.normalize import build_collection_from_table
 from rasteret.types import BoundingBox, DateRange
 
 logger = logging.getLogger(__name__)
-_STATIC_BAND_MAP_PREFLIGHT_ITEMS = 20
 
 
 def _is_retryable_stac_api_error(exc: Exception) -> bool:
@@ -471,7 +470,6 @@ class StacCollectionBuilder(CollectionBuilder):
                 )
 
         items: list[dict] = []
-        band_map_preflight_done = False
         for item in catalog.get_all_items():
             # Resolve relative hrefs to absolute URLs
             item.make_asset_hrefs_absolute()
@@ -496,16 +494,10 @@ class StacCollectionBuilder(CollectionBuilder):
                         continue
 
             items.append(item_dict)
-            if (
-                not band_map_preflight_done
-                and len(items) >= _STATIC_BAND_MAP_PREFLIGHT_ITEMS
-            ):
-                self._ensure_band_map_matches_assets(items)
-                band_map_preflight_done = True
             if max_items and len(items) >= max_items:
                 break
 
-        if items and not band_map_preflight_done:
+        if items:
             self._ensure_band_map_matches_assets(items)
 
         return items
@@ -516,8 +508,25 @@ class StacCollectionBuilder(CollectionBuilder):
         explicit_map = self._band_map is not None
         resolved = self.band_map
 
-        if resolved and self._mapped_asset_keys(resolved, asset_keys):
-            return
+        if resolved:
+            if explicit_map:
+                missing = set(resolved.values()) - asset_keys
+                if not missing:
+                    return
+                detected = self._format_asset_keys(asset_keys)
+                expected = self._format_asset_keys(set(resolved.values()))
+                missing_text = self._format_asset_keys(missing)
+                raise ValueError(
+                    "STAC band_map references asset keys not present in the "
+                    "selected STAC items. "
+                    f"Missing asset keys: {missing_text}. "
+                    f"Configured asset keys: {expected}. "
+                    f"Detected asset keys: {detected}. "
+                    "Individual items may omit valid bands, but every configured "
+                    "asset key must appear at least once in the selected result."
+                )
+            if self._mapped_asset_keys(resolved, asset_keys):
+                return
 
         if not explicit_map:
             inferred = self._infer_band_map_from_assets(asset_keys)

--- a/src/rasteret/tests/test_cog_reader.py
+++ b/src/rasteret/tests/test_cog_reader.py
@@ -174,14 +174,16 @@ def test_cog_reader_reads_local_file_ranges(tmp_path: Path) -> None:
             return await reader._read_range(str(path), 2, 6)
 
     out = asyncio.run(_read())
-    assert out == payload[2:6]
+    assert not isinstance(out, bytes)
+    assert memoryview(out).tobytes() == payload[2:6]
 
     async def _read_file_uri() -> bytes:
         async with COGReader(max_concurrent=1) as reader:
             return await reader._read_range(path.as_uri(), 2, 6)
 
     out_uri = asyncio.run(_read_file_uri())
-    assert out_uri == payload[2:6]
+    assert not isinstance(out_uri, bytes)
+    assert memoryview(out_uri).tobytes() == payload[2:6]
 
 
 @pytest.mark.asyncio

--- a/src/rasteret/tests/test_compat_matrix.py
+++ b/src/rasteret/tests/test_compat_matrix.py
@@ -116,7 +116,11 @@ def _minimal_item(
             "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
         },
         "bbox": [0.0, 0.0, 1.0, 1.0],
-        "properties": {"datetime": "2024-01-10T00:00:00Z", "eo:cloud_cover": 0.0},
+        "properties": {
+            "datetime": "2024-01-10T00:00:00Z",
+            "eo:cloud_cover": 0.0,
+            "proj:code": "EPSG:4326",
+        },
         "assets": {k: {"href": v} for k, v in hrefs.items()},
     }
 

--- a/src/rasteret/tests/test_header_parser_local.py
+++ b/src/rasteret/tests/test_header_parser_local.py
@@ -56,6 +56,33 @@ async def test_header_parser_matches_tiled_fixture_metadata(
 
 
 @pytest.mark.asyncio
+async def test_header_parser_reads_local_paths_without_custom_backend(
+    tmp_path: Path,
+) -> None:
+    import numpy as np
+
+    fixture = tmp_path / "local-default-backend.tif"
+    data = np.zeros((128, 128), dtype=np.uint16)
+    extratags = [
+        (33550, "d", 3, (1.0, 1.0, 0.0), False),
+        (33922, "d", 6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), False),
+    ]
+    tf.imwrite(fixture, data, tile=(64, 64), extratags=extratags)
+
+    parser = AsyncCOGHeaderParser(max_concurrent=1, batch_size=1)
+    meta = await parser.parse_cog_header(str(fixture))
+    assert meta is not None
+    assert meta.width == 128
+    assert meta.tile_offsets
+
+    parser_uri = AsyncCOGHeaderParser(max_concurrent=1, batch_size=1)
+    meta_uri = await parser_uri.parse_cog_header(fixture.as_uri())
+    assert meta_uri is not None
+    assert meta_uri.width == 128
+    assert meta_uri.tile_byte_counts == meta.tile_byte_counts
+
+
+@pytest.mark.asyncio
 async def test_header_parser_skips_non_tiled_bigtiff(
     async_tiff_bigtiff_fixtures: Path,
 ) -> None:

--- a/src/rasteret/tests/test_ingest.py
+++ b/src/rasteret/tests/test_ingest.py
@@ -13,6 +13,7 @@ import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 import pytest
 import tifffile as tf
+from pyproj import CRS
 
 from rasteret.core.collection import Collection
 from rasteret.ingest.enrich import (
@@ -114,6 +115,40 @@ class TestBuildCollectionFromTable:
         out_dir = tmp_path / "output"
         build_collection_from_table(table, workspace_dir=out_dir)
         assert out_dir.exists()
+
+    def test_normalizes_proj_code_into_raster_crs_sidecars(self):
+        table = _minimal_table(
+            **{
+                "proj:code": pa.array(["EPSG:32632", "EPSG:32633"]),
+                "proj:epsg": pa.array([99999, 99999], type=pa.int32()),
+            }
+        )
+        collection = build_collection_from_table(table)
+        out = collection.dataset.to_table(columns=["proj:epsg", "crs"])
+        assert out.column("proj:epsg").to_pylist() == [32632, 32633]
+        assert out.column("crs").to_pylist() == ["EPSG:32632", "EPSG:32633"]
+
+    @pytest.mark.parametrize(
+        ("column_name", "value_factory"),
+        [
+            ("proj:wkt2", lambda epsg: CRS.from_epsg(epsg).to_wkt()),
+            ("proj:projjson", lambda epsg: CRS.from_epsg(epsg).to_json_dict()),
+        ],
+    )
+    def test_normalizes_projection_metadata_into_raster_crs_sidecars(
+        self, column_name, value_factory
+    ):
+        table = _minimal_table(
+            **{
+                column_name: pa.array(
+                    [value_factory(32632), value_factory(32633)],
+                )
+            }
+        )
+        collection = build_collection_from_table(table)
+        out = collection.dataset.to_table(columns=["proj:epsg", "crs"])
+        assert out.column("proj:epsg").to_pylist() == [32632, 32633]
+        assert out.column("crs").to_pylist() == ["EPSG:32632", "EPSG:32633"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/rasteret/tests/test_ingest.py
+++ b/src/rasteret/tests/test_ingest.py
@@ -457,6 +457,42 @@ class TestBuildFromTable:
         ids = collection.dataset.to_table(columns=["id"]).column("id").to_pylist()
         assert ids == ["scene-2"]
 
+    def test_build_from_table_enriches_local_tiff_without_custom_backend(
+        self, tmp_path
+    ):
+        import numpy as np
+
+        import rasteret
+
+        cog_path = tmp_path / "local.tif"
+        data = np.zeros((128, 128), dtype=np.uint16)
+        extratags = [
+            (33550, "d", 3, (1.0, 1.0, 0.0), False),
+            (33922, "d", 6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), False),
+        ]
+        tf.imwrite(cog_path, data, tile=(64, 64), extratags=extratags)
+
+        table = pa.table(
+            {
+                "id": pa.array(["scene-1"]),
+                "datetime": pa.array([datetime(2024, 1, 1)], type=pa.timestamp("us")),
+                "geometry": pa.array([None], type=pa.null()),
+                "assets": pa.array([{"B01": {"href": str(cog_path)}}]),
+            }
+        )
+
+        collection = rasteret.build_from_table(
+            table,
+            enrich_cog=True,
+            band_codes=["B01"],
+        )
+
+        out = collection.dataset.to_table(columns=["B01_metadata"])
+        metadata = out.column("B01_metadata").to_pylist()[0]
+        assert metadata is not None
+        assert metadata["image_width"] == 128
+        assert metadata["tile_offsets"]
+
     def test_build_from_table_hf_uri_uses_hf_reader(self):
         import rasteret
 
@@ -620,12 +656,6 @@ async def test_enrich_slices_tile_tables_for_planar_separate_multisample(tmp_pat
     """
     import numpy as np
 
-    class LocalFileBackend:
-        async def get_range(self, url: str, start: int, length: int) -> bytes:
-            with open(url, "rb") as f:
-                f.seek(start)
-                return f.read(length)
-
     path = tmp_path / "planar_separate.tif"
     data = np.zeros((2, 128, 128), dtype=np.int8)
     extratags = [
@@ -674,7 +704,6 @@ async def test_enrich_slices_tile_tables_for_planar_separate_multisample(tmp_pat
         ["A0", "A1"],
         max_concurrent=1,
         batch_size=10,
-        backend=LocalFileBackend(),
     )
 
     m0 = enriched.column("A0_metadata").to_pylist()[0]

--- a/src/rasteret/tests/test_obstore_routing.py
+++ b/src/rasteret/tests/test_obstore_routing.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -164,6 +165,44 @@ class TestAutoObstoreBackendRouting:
         store, path = backend._store_for("https://example.com/data/file.tif")
         assert path == "data/file.tif"
         assert "https://example.com/" in backend._stores
+
+    def test_local_paths_read_through_obstore_buffers(self, tmp_path: Path):
+        payload = b"0123456789abcdef"
+        path = tmp_path / "payload.bin"
+        path.write_bytes(payload)
+        backend = _create_obstore_backend()
+
+        result = asyncio.run(backend.get_range(str(path), 2, 6))
+
+        assert not isinstance(result, bytes)
+        assert memoryview(result).tobytes() == payload[2:8]
+
+    def test_file_uri_paths_read_through_obstore_buffers(self, tmp_path: Path):
+        payload = b"0123456789abcdef"
+        path = tmp_path / "payload.bin"
+        path.write_bytes(payload)
+        backend = _create_obstore_backend()
+
+        result = asyncio.run(backend.get_range(path.as_uri(), 4, 5))
+
+        assert not isinstance(result, bytes)
+        assert memoryview(result).tobytes() == payload[4:9]
+
+    def test_local_multi_range_reads_return_buffer_protocol_objects(
+        self, tmp_path: Path
+    ):
+        payload = b"0123456789abcdef"
+        path = tmp_path / "payload.bin"
+        path.write_bytes(payload)
+        backend = _create_obstore_backend()
+
+        result = asyncio.run(backend.get_ranges(str(path), [(1, 3), (8, 4)]))
+
+        assert all(not isinstance(chunk, bytes) for chunk in result)
+        assert [memoryview(chunk).tobytes() for chunk in result] == [
+            payload[1:4],
+            payload[8:12],
+        ]
 
     def test_s3_overrides_applied(self):
         backend = _create_obstore_backend(

--- a/src/rasteret/tests/test_stac_indexer.py
+++ b/src/rasteret/tests/test_stac_indexer.py
@@ -14,6 +14,7 @@ import numpy as np
 import pystac
 import pytest
 import tifffile as tf
+from pyproj import CRS
 from pystac_client.exceptions import APIError
 
 from rasteret.cloud import CloudConfig
@@ -105,7 +106,7 @@ def _write_static_catalog_with_tiff(
         },
         bbox=[0, 0, 1, 1],
         datetime=datetime(2024, 1, 1, 0, 0, 0),
-        properties={},
+        properties={"proj:code": "EPSG:4326"},
         collection=collection_id,
     )
     item.add_asset(asset_key, pystac.Asset(href=f"{asset_key}.tif"))
@@ -383,6 +384,168 @@ class TestStacCollectionBuilder:
         )
 
         assert builder.band_map["B02"] == "blue"
+
+    @patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser")
+    @patch("rasteret.ingest.stac_indexer.pystac_client")
+    def test_build_uses_proj_code_for_record_crs(
+        self, mock_pystac, mock_parser, mock_cog_metadata, tmp_path
+    ):
+        item = pystac.Item(
+            id="test_scene_1",
+            datetime=datetime(2023, 1, 1, 0, 0, 0),
+            geometry={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            bbox=[0, 0, 1, 1],
+            properties={
+                "datetime": datetime(2023, 1, 1, 0, 0, 0),
+                "proj:code": "EPSG:32632",
+                "proj:epsg": 32631,
+            },
+            assets={"B1": pystac.Asset(href="s3://test-bucket/test1_B1.tif")},
+        )
+        mock_client = MagicMock()
+        mock_search = MagicMock()
+        mock_pystac.Client.open.return_value = mock_client
+        mock_client.search.return_value = mock_search
+        mock_search.items_as_dicts.return_value = [item.to_dict()]
+
+        mock_parser_instance = AsyncMock()
+        mock_parser.return_value.__aenter__.return_value = mock_parser_instance
+        meta = CogMetadata(**{**mock_cog_metadata.__dict__, "crs": None})
+        mock_parser_instance.process_cog_headers_batch.return_value = [meta]
+
+        builder = StacCollectionBuilder(
+            data_source="test-source",
+            stac_api="https://test-stac.com",
+            workspace_dir=tmp_path / "test_output",
+            band_map={"B1": "B1"},
+        )
+
+        collection = asyncio.run(builder.build_index())
+        out = collection.dataset.to_table(columns=["proj:epsg", "crs"])
+        assert out.column("proj:epsg").to_pylist() == [32632]
+        assert out.column("crs").to_pylist() == ["EPSG:32632"]
+
+    @patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser")
+    @patch("rasteret.ingest.stac_indexer.pystac_client")
+    def test_build_falls_back_to_cog_header_crs_when_projection_property_missing(
+        self, mock_pystac, mock_parser, mock_cog_metadata, tmp_path
+    ):
+        item = pystac.Item(
+            id="test_scene_1",
+            datetime=datetime(2023, 1, 1, 0, 0, 0),
+            geometry={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            bbox=[0, 0, 1, 1],
+            properties={"datetime": datetime(2023, 1, 1, 0, 0, 0)},
+            assets={"B1": pystac.Asset(href="s3://test-bucket/test1_B1.tif")},
+        )
+        mock_client = MagicMock()
+        mock_search = MagicMock()
+        mock_pystac.Client.open.return_value = mock_client
+        mock_client.search.return_value = mock_search
+        mock_search.items_as_dicts.return_value = [item.to_dict()]
+
+        mock_parser_instance = AsyncMock()
+        mock_parser.return_value.__aenter__.return_value = mock_parser_instance
+        mock_parser_instance.process_cog_headers_batch.return_value = [
+            mock_cog_metadata
+        ]
+
+        builder = StacCollectionBuilder(
+            data_source="test-source",
+            stac_api="https://test-stac.com",
+            workspace_dir=tmp_path / "test_output",
+            band_map={"B1": "B1"},
+        )
+
+        collection = asyncio.run(builder.build_index())
+        out = collection.dataset.to_table(columns=["proj:epsg", "crs"])
+        assert out.column("proj:epsg").to_pylist() == [4326]
+        assert out.column("crs").to_pylist() == ["EPSG:4326"]
+
+    @patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser")
+    @patch("rasteret.ingest.stac_indexer.pystac_client")
+    def test_build_uses_proj_wkt2_for_record_crs(
+        self, mock_pystac, mock_parser, mock_cog_metadata, tmp_path
+    ):
+        item = pystac.Item(
+            id="test_scene_1",
+            datetime=datetime(2023, 1, 1, 0, 0, 0),
+            geometry={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            bbox=[0, 0, 1, 1],
+            properties={
+                "datetime": datetime(2023, 1, 1, 0, 0, 0),
+                "proj:wkt2": CRS.from_epsg(32632).to_wkt(),
+            },
+            assets={"B1": pystac.Asset(href="s3://test-bucket/test1_B1.tif")},
+        )
+        mock_client = MagicMock()
+        mock_search = MagicMock()
+        mock_pystac.Client.open.return_value = mock_client
+        mock_client.search.return_value = mock_search
+        mock_search.items_as_dicts.return_value = [item.to_dict()]
+
+        mock_parser_instance = AsyncMock()
+        mock_parser.return_value.__aenter__.return_value = mock_parser_instance
+        meta = CogMetadata(**{**mock_cog_metadata.__dict__, "crs": None})
+        mock_parser_instance.process_cog_headers_batch.return_value = [meta]
+
+        builder = StacCollectionBuilder(
+            data_source="test-source",
+            stac_api="https://test-stac.com",
+            workspace_dir=tmp_path / "test_output",
+            band_map={"B1": "B1"},
+        )
+
+        collection = asyncio.run(builder.build_index())
+        out = collection.dataset.to_table(columns=["proj:epsg", "crs"])
+        assert out.column("proj:epsg").to_pylist() == [32632]
+        assert out.column("crs").to_pylist() == ["EPSG:32632"]
+
+    @patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser")
+    @patch("rasteret.ingest.stac_indexer.pystac_client")
+    def test_build_raises_early_when_record_crs_cannot_be_resolved(
+        self, mock_pystac, mock_parser, mock_cog_metadata, tmp_path
+    ):
+        item = pystac.Item(
+            id="test_scene_1",
+            datetime=datetime(2023, 1, 1, 0, 0, 0),
+            geometry={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            bbox=[0, 0, 1, 1],
+            properties={"datetime": datetime(2023, 1, 1, 0, 0, 0)},
+            assets={"B1": pystac.Asset(href="s3://test-bucket/test1_B1.tif")},
+        )
+        mock_client = MagicMock()
+        mock_search = MagicMock()
+        mock_pystac.Client.open.return_value = mock_client
+        mock_client.search.return_value = mock_search
+        mock_search.items_as_dicts.return_value = [item.to_dict()]
+
+        mock_parser_instance = AsyncMock()
+        mock_parser.return_value.__aenter__.return_value = mock_parser_instance
+        meta = CogMetadata(**{**mock_cog_metadata.__dict__, "crs": None})
+        mock_parser_instance.process_cog_headers_batch.return_value = [meta]
+
+        builder = StacCollectionBuilder(
+            data_source="test-source",
+            stac_api="https://test-stac.com",
+            workspace_dir=tmp_path / "test_output",
+            band_map={"B1": "B1"},
+        )
+
+        with pytest.raises(ValueError, match="Raster CRS could not be resolved"):
+            asyncio.run(builder.build_index())
 
 
 def test_retryable_stac_api_error_detection() -> None:

--- a/src/rasteret/tests/test_stac_indexer.py
+++ b/src/rasteret/tests/test_stac_indexer.py
@@ -119,6 +119,40 @@ def _write_static_catalog_with_tiff(
     return root / "catalog.json", cog_path
 
 
+def _write_static_catalog_with_asset_sequence(
+    tmp_path,
+    asset_keys: list[str],
+    *,
+    collection_id: str = "mixed_catalog",
+) -> Path:
+    root = tmp_path / "catalog"
+    root.mkdir()
+    catalog = pystac.Catalog(id=collection_id, description="mixed static")
+
+    for idx, asset_key in enumerate(asset_keys):
+        item_dir = root / f"tile-{idx}"
+        item_dir.mkdir()
+        item = pystac.Item(
+            id=f"scene-{idx}",
+            geometry={
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+            },
+            bbox=[0, 0, 1, 1],
+            datetime=datetime(2024, 1, 1, 0, 0, 0),
+            properties={},
+            collection=collection_id,
+        )
+        item.add_asset(asset_key, pystac.Asset(href=f"{asset_key}.tif"))
+        item.set_self_href(str(item_dir / f"scene-{idx}.json"))
+        item.save_object()
+        catalog.add_item(item)
+
+    catalog.normalize_hrefs(str(root))
+    catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+    return root / "catalog.json"
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -293,7 +327,7 @@ class TestStacCollectionBuilder:
         catalog_path, _ = _write_static_catalog_with_tiff(tmp_path, asset_key="B01")
 
         with patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser") as parser:
-            with pytest.raises(ValueError, match="No STAC asset keys matched"):
+            with pytest.raises(ValueError, match="Missing asset keys: red"):
                 rasteret.build_from_stac(
                     name="local-static-mismatch",
                     stac_api=str(catalog_path),
@@ -305,6 +339,41 @@ class TestStacCollectionBuilder:
                     force=True,
                 )
             parser.assert_not_called()
+
+    def test_static_catalog_fails_fast_when_band_map_has_partial_typo(self, tmp_path):
+        import rasteret
+
+        catalog_path, _ = _write_static_catalog_with_tiff(tmp_path, asset_key="B01")
+
+        with patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser") as parser:
+            with pytest.raises(ValueError, match="Missing asset keys: B02"):
+                rasteret.build_from_stac(
+                    name="local-static-partial-mismatch",
+                    stac_api=str(catalog_path),
+                    collection="S2_L2A_catalog",
+                    static_catalog=True,
+                    band_map={"B01": "B01", "B02": "B02"},
+                    workspace_dir=tmp_path / "workspace",
+                    max_concurrent=1,
+                    force=True,
+                )
+            parser.assert_not_called()
+
+    def test_static_catalog_validates_against_full_selected_asset_union(self, tmp_path):
+        catalog_path = _write_static_catalog_with_asset_sequence(
+            tmp_path,
+            ["B01"] * 20 + ["B02"],
+        )
+        builder = StacCollectionBuilder(
+            data_source="mixed_catalog",
+            stac_api=str(catalog_path),
+            band_map={"B01": "B01", "B02": "B02"},
+            static_catalog=True,
+        )
+
+        items = builder._crawl_static_catalog(None, None)
+
+        assert len(items) == 21
 
     def test_sentinel2_registry_common_name_map_is_preserved(self):
         builder = StacCollectionBuilder(

--- a/src/rasteret/tests/test_stac_indexer.py
+++ b/src/rasteret/tests/test_stac_indexer.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pystac
 import pytest
+import tifffile as tf
 from pystac_client.exceptions import APIError
 
 from rasteret.cloud import CloudConfig
@@ -75,6 +78,45 @@ def cloud_config():
         region="us-west-2",
         url_patterns={"https://test.com/": "s3://test-bucket/"},
     )
+
+
+def _write_static_catalog_with_tiff(
+    tmp_path,
+    *,
+    asset_key: str = "B01",
+    collection_id: str = "S2_L2A_catalog",
+) -> tuple[Path, Path]:
+    root = tmp_path / "catalog"
+    item_dir = root / "tile"
+    item_dir.mkdir(parents=True)
+    cog_path = item_dir / f"{asset_key}.tif"
+    data = np.zeros((128, 128), dtype=np.uint16)
+    extratags = [
+        (33550, "d", 3, (1.0, 1.0, 0.0), False),
+        (33922, "d", 6, (0.0, 0.0, 0.0, 0.0, 0.0, 0.0), False),
+    ]
+    tf.imwrite(cog_path, data, tile=(64, 64), extratags=extratags)
+
+    item = pystac.Item(
+        id="scene-1",
+        geometry={
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+        bbox=[0, 0, 1, 1],
+        datetime=datetime(2024, 1, 1, 0, 0, 0),
+        properties={},
+        collection=collection_id,
+    )
+    item.add_asset(asset_key, pystac.Asset(href=f"{asset_key}.tif"))
+    item.set_self_href(str(item_dir / "scene-1.json"))
+    item.save_object()
+
+    catalog = pystac.Catalog(id=collection_id, description="local static")
+    catalog.add_item(item)
+    catalog.normalize_hrefs(str(root))
+    catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+    return root / "catalog.json", cog_path
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +247,73 @@ class TestStacCollectionBuilder:
 
         url = builder._get_asset_url({"href": "https://other.com/asset.tif"})
         assert url == "https://other.com/asset.tif"
+
+    def test_static_catalog_build_enriches_relative_local_asset(self, tmp_path):
+        import rasteret
+
+        catalog_path, _ = _write_static_catalog_with_tiff(tmp_path)
+
+        collection = rasteret.build_from_stac(
+            name="local-static",
+            stac_api=str(catalog_path),
+            collection="S2_L2A_catalog",
+            static_catalog=True,
+            workspace_dir=tmp_path / "workspace",
+            max_concurrent=1,
+            force=True,
+        )
+
+        out = collection.dataset.to_table(columns=["B01_metadata"])
+        metadata = out.column("B01_metadata").to_pylist()[0]
+        assert metadata is not None
+        assert metadata["image_width"] == 128
+        assert metadata["tile_offsets"]
+
+    def test_static_catalog_explicit_band_map_subset(self, tmp_path):
+        import rasteret
+
+        catalog_path, _ = _write_static_catalog_with_tiff(tmp_path)
+
+        collection = rasteret.build_from_stac(
+            name="local-static-subset",
+            stac_api=str(catalog_path),
+            collection="S2_L2A_catalog",
+            static_catalog=True,
+            band_map={"B01": "B01"},
+            workspace_dir=tmp_path / "workspace",
+            max_concurrent=1,
+            force=True,
+        )
+
+        assert "B01_metadata" in collection.dataset.schema.names
+
+    def test_static_catalog_fails_fast_when_band_map_matches_no_assets(self, tmp_path):
+        import rasteret
+
+        catalog_path, _ = _write_static_catalog_with_tiff(tmp_path, asset_key="B01")
+
+        with patch("rasteret.ingest.stac_indexer.AsyncCOGHeaderParser") as parser:
+            with pytest.raises(ValueError, match="No STAC asset keys matched"):
+                rasteret.build_from_stac(
+                    name="local-static-mismatch",
+                    stac_api=str(catalog_path),
+                    collection="S2_L2A_catalog",
+                    static_catalog=True,
+                    band_map={"B04": "red"},
+                    workspace_dir=tmp_path / "workspace",
+                    max_concurrent=1,
+                    force=True,
+                )
+            parser.assert_not_called()
+
+    def test_sentinel2_registry_common_name_map_is_preserved(self):
+        builder = StacCollectionBuilder(
+            data_source="sentinel-2-l2a",
+            stac_api="https://example.com",
+            stac_collection="sentinel-2-l2a",
+        )
+
+        assert builder.band_map["B02"] == "blue"
 
 
 def test_retryable_stac_api_error_detection() -> None:


### PR DESCRIPTION
## What does this PR do?

Based on issue #27 Static STAC catalogs on local filesystems resolved relative asset hrefs correctly, but the default range backend treated local paths as HTTP-like URLs. That made bare paths fail with 'relative URL without a base' and file:// paths surface an obstore Rust panic. Route local paths through obstore LocalStore so build_from_stac(), build_from_table(enrich_cog=True), and COGReader all share the same byte-range backend behavior.

The default obstore backend now preserves obstore's buffer-protocol objects instead of eagerly copying every range to Python bytes. TIFF header parsing decodes small ASCII/XML tag payloads explicitly where strings are required, while tile/header byte ranges can remain bytes-like buffers.

Static STAC builds now validate band maps before COG header enrichment and can infer simple identity maps from STAC asset keys such as Sentinel-2 B01/B02 when no registered provider map exists.

## Checklist

- [X] Tests pass (`uv run pytest -q`)
- [X] Tests with network IO pass (`uv run pytest --network -m network -q`)
- [X] Linting passes (`uv run ruff check src/ && uv run ruff format --check src/`)
- [X] Docs build cleanly (`uv run mkdocs build --strict`) if docs were changed
